### PR TITLE
delete duplicate for loop.

### DIFF
--- a/src/oracle/monitor.js
+++ b/src/oracle/monitor.js
@@ -83,23 +83,7 @@ export const monitor = async () => {
 
         state.updateOracleState(oracle, latestOracleState);
       }
-
-      // Once all oracles were queried, get consensus time for each feed
-      for (let feed in lastRound) {
-        let feedLastRound = lastRound[feed];
-
-        // If there were at least  3 submissions
-        if (feedLastRound.submissions.length >= 3) {
-          // First sort the array
-          feedLastRound.submissions.sort((a, b) => a - b);
-          // Calculate consensus time, subtract third time from first
-          let consensusTime =
-            feedLastRound.submissions[2] - feedLastRound.submissions[0];
-          // Update metric
-          metrics.updateConsensusTimeTaken(feed, consensusTime);
-        }
-      }
-
+ 
       // Once all oracles were queried, get consensus time for each feed
       for (let feed in lastRound) {
         let feedLastRound = lastRound[feed];


### PR DESCRIPTION
The entire for loop under the comment `Once all oracles were queried, get consensus time for each feed` is duplicated. All of the effects happen in `metrics.updateConsensusTimeTaken(feed, consensusTime);`, so the duplication should be idempotent.